### PR TITLE
build: enable compile warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,6 @@ project(open-cycle-time)
 
 set(CMAKE_CXX_STANDARD 11)
 
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+
 add_executable(open-cycle-time main.cpp)


### PR DESCRIPTION
### Description
<!-- Include a summary of the changes and which issue is closed/fixed. -->
Simply enabling warnings as errors in CMake.

Closes #36 

### Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branching follow the Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [ ] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [x] Has code been linted locally prior to submission?
- [ ] Have you added corresponding changes to documentation?
- [ ] Have you introduced new dependencies?