### PR TITLE
build: add opencv using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_package(OpenCV REQUIRED)
+
 include(FetchContent)
 
 set(FETCHCONTENT_QUIET FALSE)
@@ -85,6 +87,7 @@ set(PROJECT_SOURCES
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_DEPENDENCIES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${OpenCV_LIBS})
 
 include(CTest)
 add_subdirectory(test)


### PR DESCRIPTION
### Description
<!-- Include a summary of the changes and which issue is closed/fixed. -->
OpenCV is the last core dependency. Although not fetched or installed using CMake, this commit still achieves the cross-platform build integrating the library.

Closes #82

### Checklist
- [ ] Relevant issue linked.
- [ ] No other open pull requests for the same issue?
- [ ] This pull request targets develop and not main.
- [ ] Does your branching follow the Git Flow strategy?
- [ ] You have only one commit? If not squash into one.
- [ ] Does commit message follow conventional commit strategy?
- [ ] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [ ] Has code been linted locally prior to submission?
- [ ] Have you added corresponding changes to documentation?
- [ ] Have you introduced new dependencies?
