### PR TITLE
build: add tiny file dialogs using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,17 @@ FetchContent_Declare(
         GIT_TAG d87512353495e7760e7fda7566a05beef7627d8f
         GIT_PROGRESS TRUE)
 
+FetchContent_Declare(
+        tinyfiledialogs
+        GIT_REPOSITORY https://git.code.sf.net/p/tinyfiledialogs/code
+        GIT_PROGRESS TRUE)
+
 set(PROJECT_DEPENDENCIES
         glfw
         glad
         imgui
-        implot)
+        implot
+        tinyfiledialogs)
 
 FetchContent_MakeAvailable(${PROJECT_DEPENDENCIES})
 
@@ -78,6 +84,11 @@ add_library(implot STATIC
 target_include_directories(implot PUBLIC
         ${implot_SOURCE_DIR}
         ${imgui_SOURCE_DIR})
+
+add_library(tinyfiledialogs STATIC
+        ${tinyfiledialogs_SOURCE_DIR}/tinyfiledialogs.c)
+
+target_include_directories(tinyfiledialogs PUBLIC ${tinyfiledialogs_SOURCE_DIR})
 
 set(PROJECT_SOURCES
         main.cpp


### PR DESCRIPTION
### Description
<!-- Include a summary of the changes and which issue is closed/fixed. -->
Integrating tiny file dialogs to allow for the use of the native file explorer and ultimately to find our video files to analyze.

Closes #91

### Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branching follow the Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [x] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [ ] Has code been linted locally prior to submission?
- [ ] Have you added corresponding changes to documentation?
- [x] Have you introduced new dependencies?
