### PR TITLE
feat: add open file dialogs for loading videos

### DIFF
--- a/include/gui_context.h
+++ b/include/gui_context.h
@@ -5,7 +5,9 @@
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>
 #include <imgui.h>
+#include <opencv2/opencv.hpp>
 #include <string>
+#include <vector>
 
 namespace oct {
 class GUIContext {
@@ -24,6 +26,14 @@ private:
     int display_h;
     ImVec4 clear_color = ImVec4(0.29f, 0.29f, 0.38f, 0.4f);
     std::string file_name;
+    bool typeCheck();
+    cv::Mat frame;
+    std::vector<cv::Mat> frames;
+    int frame_rate;
+    int first_frame;
+    int last_frame;
+    int max_frame;
+    float video_length;
     static void errorCallbackGLFW(int error, const char* description);
     static GLFWwindow* initialiseGLFW(const std::string& window_title,
                                       unsigned short width,

--- a/src/gui_context.cpp
+++ b/src/gui_context.cpp
@@ -9,7 +9,15 @@ namespace oct {
 GUIContext::GUIContext(const std::string& window_title, unsigned short width,
                        unsigned short height)
     : window{initialiseGLFW(window_title, width, height)}
-    , io{GUIContext::initialiseIMGUI()} {}
+    , io{GUIContext::initialiseIMGUI()}
+    , display_w{0}
+    , display_h{0}
+    , file_name{""}
+    , frame_rate{0}
+    , first_frame{1}
+    , last_frame{0}
+    , max_frame{0}
+    , video_length{0.0} {}
 GUIContext::~GUIContext() {
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
@@ -64,6 +72,29 @@ GLFWwindow* GUIContext::initialiseGLFW(const std::string& window_title,
     glfwSwapInterval(1);
 
     return window;
+}
+bool GUIContext::typeCheck() {
+    std::string ending_one = "mp4";
+    std::string ending_two = "avi";
+    std::string ending_three = "mov";
+    if (file_name.length() >= ending_one.length()) {
+        if (0
+            == file_name.compare(file_name.length() - ending_one.length(),
+                                 ending_one.length(), ending_one)) {
+            return true;
+        } else if (0
+                   == file_name.compare(file_name.length()
+                                            - ending_two.length(),
+                                        ending_two.length(), ending_two)) {
+            return true;
+        } else if (0
+                   == file_name.compare(file_name.length()
+                                            - ending_three.length(),
+                                        ending_three.length(), ending_three)) {
+            return true;
+        }
+    }
+    return false;
 }
 void GUIContext::errorCallbackGLFW(int error, const char* description) {
     std::cerr << "GLFW Error (" << error << ") " << description << std::endl;
@@ -141,10 +172,41 @@ void GUIContext::buildGUI() {
         ImPlot::ShowMetricsWindow(&show_implot_metrics);
     }
 
+    // loader variables
+    static bool show_load_dialog = false;
+    static bool skip_load_file = false;
+    static bool show_load_error = false;
+    static bool skip_loader_check = false;
+    static bool skip_get_size = false;
+    static bool show_video_size = false;
+    static bool right_type = false;
+    static bool load_full = false;
+    static bool load_portion = false;
+    static bool ready_load_portion = false;
+
     // Main menu bar
     if (ImGui::BeginMainMenuBar()) {
         if (ImGui::BeginMenu("File")) {
             if (ImGui::MenuItem("Open", nullptr)) {
+                // reset all loader variables when loading a new video
+                show_load_dialog = false;
+                skip_load_file = false;
+                show_load_error = false;
+                skip_loader_check = false;
+                skip_get_size = false;
+                show_video_size = false;
+                right_type = false;
+                load_full = false;
+                load_portion = false;
+                ready_load_portion = false;
+                file_name = "";
+                frames.clear();
+                frame_rate = 0;
+                first_frame = 1;
+                last_frame = 0;
+                max_frame = 0;
+                video_length = 0.0;
+
                 char const* lTheOpenFileName;
                 char const* lFilterPatterns[3] = {"*.mp4", "*.avi", "*.mov"};
                 lTheOpenFileName =
@@ -155,6 +217,10 @@ void GUIContext::buildGUI() {
                                       "error", 0);
                 } else {
                     file_name = lTheOpenFileName;
+                    if (typeCheck()) {
+                        right_type = true;
+                    }
+                    show_load_dialog = true;
                 }
             }
             if (ImGui::MenuItem("Quit", nullptr)) {
@@ -178,6 +244,145 @@ void GUIContext::buildGUI() {
         }
         ImGui::EndMainMenuBar();
     }
+
+    // Main Window
+    static bool show_main_window = true;
+    static bool use_work_area = true;
+    // static bool show_splash = true;
+
+    static ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground
+        | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize
+        | ImGuiWindowFlags_NoSavedSettings;
+    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(use_work_area ? viewport->WorkPos : viewport->Pos);
+    ImGui::SetNextWindowSize(use_work_area ? viewport->WorkSize
+                                           : viewport->Size);
+
+    if (ImGui::Begin("Open Cycle Time - Main Window", &show_main_window,
+                     flags)) {
+        if (show_load_dialog) {
+            if (show_load_error) {
+                ImGui::OpenPopup("Error:");
+                ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+                ImGui::SetNextWindowPos(center, ImGuiCond_Appearing,
+                                        ImVec2(0.5f, 0.5f));
+                if (ImGui::BeginPopupModal("Error:", NULL,
+                                           ImGuiWindowFlags_AlwaysAutoResize)) {
+                    ImGui::Text("The selected file cannot be opened.");
+                    ImGui::Separator();
+                    // ImGui::PopStyleVar();
+                    if (ImGui::Button("OK", ImVec2(120, 0))) {
+                        ImGui::CloseCurrentPopup();
+                        show_load_dialog = false;
+                    }
+                    ImGui::EndPopup();
+                }
+            }
+            if (!skip_load_file) {
+                cv::VideoCapture frame_loader(file_name);
+                if (right_type && frame_loader.isOpened()) {
+                    if (!skip_get_size) {
+                        frame_rate = frame_loader.get(cv::CAP_PROP_FPS);
+                        while (true) {
+                            frame_loader >> frame;
+                            if (frame.empty()) {
+                                break;
+                            }
+                            last_frame++;
+                        }
+                        max_frame = last_frame;
+                        skip_get_size = true;
+                        show_video_size = true;
+                    }
+                    if (show_video_size) {
+                        ImGui::OpenPopup("Video File Info:");
+                        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+                        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing,
+                                                ImVec2(0.5f, 0.5f));
+                        if (ImGui::BeginPopupModal(
+                                "Video File Info:", NULL,
+                                ImGuiWindowFlags_AlwaysAutoResize)) {
+                            video_length = last_frame / frame_rate;
+                            ImGui::Text(
+                                "The selected file contains %d frames and is "
+                                "%.02f seconds long.\n\nDo you want to load "
+                                "the "
+                                "entire file or just a portion?",
+                                last_frame, video_length);
+                            ImGui::Separator();
+                            if (ImGui::Button("Load Portion", ImVec2(120, 0))) {
+                                show_video_size = false;
+                                load_portion = true;
+                                ImGui::CloseCurrentPopup();
+                            }
+                            ImGui::SameLine();
+                            if (ImGui::Button("Load All", ImVec2(120, 0))) {
+                                show_video_size = false;
+                                load_full = true;
+                                ImGui::CloseCurrentPopup();
+                            }
+                            ImGui::EndPopup();
+                        }
+                    }
+                    if (load_full) {
+                        last_frame = 0;
+                        while (true) {
+                            frame_loader >> frame;
+                            if (frame.empty()) {
+                                break;
+                            }
+                            frames.push_back(frame);
+                            last_frame++;
+                        }
+                        load_full = false;
+                    }
+                    if (load_portion) {
+                        ImGui::OpenPopup("Select Frames:");
+                        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+                        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing,
+                                                ImVec2(0.5f, 0.5f));
+                        if (ImGui::BeginPopupModal(
+                                "Select Frames:", NULL,
+                                ImGuiWindowFlags_AlwaysAutoResize)) {
+                            float selection_length =
+                                (last_frame - first_frame) / frame_rate;
+                            ImGui::DragInt("Start Frame", &first_frame, 0.5f, 1,
+                                           (max_frame - 1), "%d",
+                                           ImGuiSliderFlags_AlwaysClamp);
+                            ImGui::DragInt("End Frame", &last_frame, 0.5f, 2,
+                                           max_frame, "%d",
+                                           ImGuiSliderFlags_AlwaysClamp);
+                            if (ImGui::Button("Load", ImVec2(120, 0))) {
+                                ready_load_portion = true;
+                                ImGui::CloseCurrentPopup();
+                            }
+                            ImGui::SameLine();
+                            ImGui::Text("%.02f secs", selection_length);
+                            ImGui::EndPopup();
+                        }
+                        if (ready_load_portion) {
+                            for (int i = 1; i <= last_frame; i++) {
+                                if (i < first_frame) {
+                                    continue;
+                                }
+                                frame_loader >> frame;
+                                if (frame.empty()) {
+                                    break;
+                                }
+                                frames.push_back(frame);
+                            }
+                            load_portion = false;
+                        }
+                    }
+                } else {
+                    show_load_error = true;
+                    skip_load_file = true;
+                }
+            }
+        }
+    }
+    ImGui::End();
 }
 void GUIContext::renderGUI() {
     ImGui::Render();


### PR DESCRIPTION
### Description
<!-- Include a summary of the changes and which issue is closed/fixed. -->
This commit provides:
- Error windows when loading video files.
- Partial video loading and full video loading.
- Cross-platform file dialogs.
- Populates the vector holding the video frames.
- Resets all required variables when loading another video file.

Closes #93

### Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branching follow the Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [ ] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [x] Has code been linted locally prior to submission?
- [ ] Have you added corresponding changes to documentation?
- [ ] Have you introduced new dependencies?
